### PR TITLE
Chunk height gt1000

### DIFF
--- a/src/LogViewer/chunk-worker.js
+++ b/src/LogViewer/chunk-worker.js
@@ -2,9 +2,10 @@ import parseAnsi from '../util/ansi-parse';
 
 const CLEAR_ANSI = /(?:\033)(?:\[0?c|\[[0356]n|\[7[lh]|\[\?25[lh]|\(B|H|\[(?:\d+(;\d+){,2})?G|\[(?:[12])?[JK]|[DM]|\[0K)/gm;
 const CONTROL_CHARS = /\033\[1000D/gm;
-const NORMALIZE_NEWLINES = /\r+[\n]?/gm;
+const NORMALIZE_NEWLINES = /\r[\n]?/gm;
 const NEWLINE = /^/gm;
 const ENCODED_CARRIAGERETURN = 13;
+const ENCODED_NEWLINE = 10;
 const MIN_LINE_HEIGHT = 19;
 const LINE_CHUNK = 1000;
 const DECODER = new TextDecoder('utf-8');
@@ -155,7 +156,11 @@ const update = (response) => {
   chunkHeights = [];
 
   for (let index = 0; index < bufferLength; index++) {
-    if (buffer[index] === ENCODED_CARRIAGERETURN) {
+    const isNewline = buffer[index] === ENCODED_CARRIAGERETURN ||
+      (buffer[index] === ENCODED_NEWLINE &&
+        buffer[index - 1] !== ENCODED_CARRIAGERETURN);
+
+    if (isNewline) {
       newlineCount++;
     }
 

--- a/src/LogViewer/chunk-worker.js
+++ b/src/LogViewer/chunk-worker.js
@@ -2,7 +2,7 @@ import parseAnsi from '../util/ansi-parse';
 
 const CLEAR_ANSI = /(?:\033)(?:\[0?c|\[[0356]n|\[7[lh]|\[\?25[lh]|\(B|H|\[(?:\d+(;\d+){,2})?G|\[(?:[12])?[JK]|[DM]|\[0K)/gm;
 const CONTROL_CHARS = /\033\[1000D/gm;
-const NORMALIZE_NEWLINES = /\r+\n/gm;
+const NORMALIZE_NEWLINES = /\r+[\n]?/gm;
 const NEWLINE = /^/gm;
 const ENCODED_CARRIAGERETURN = 13;
 const MIN_LINE_HEIGHT = 19;

--- a/src/LogViewer/chunk-worker.js
+++ b/src/LogViewer/chunk-worker.js
@@ -4,7 +4,7 @@ const CLEAR_ANSI = /(?:\033)(?:\[0?c|\[[0356]n|\[7[lh]|\[\?25[lh]|\(B|H|\[(?:\d+
 const CONTROL_CHARS = /\033\[1000D/gm;
 const NORMALIZE_NEWLINES = /\r+\n/gm;
 const NEWLINE = /^/gm;
-const ENCODED_NEWLINE = 10;
+const ENCODED_CARRIAGERETURN = 13;
 const MIN_LINE_HEIGHT = 19;
 const LINE_CHUNK = 1000;
 const DECODER = new TextDecoder('utf-8');
@@ -82,7 +82,7 @@ const update = (response) => {
   chunkHeights = [];
 
   for (let index = 0; index < bufferLength; index++) {
-    if (buffer[index] === ENCODED_NEWLINE) {
+    if (buffer[index] === ENCODED_CARRIAGERETURN) {
       newlineCount++;
     }
 


### PR DESCRIPTION
Problem: `newlineCount` increments when it sees \n, but not every line ends with \n.
Solution: Increment `newlineCount` when it sees \r, because every line either ends with \r\n or simply \r.

Other changes:
-  Since new lines don't always end with \n, I changed `NORMALIZE_NEWLINES` to `/\r+[\n]?/gm`

This solves the issue we were having with the following [log](http://localhost:4000/?url=https%3A%2F%2Fpublic-artifacts.taskcluster.net%2F5qB6Zqc0Tw2_wkKwHgGNGQ%2F0%2Fpublic%2Flogs%2Flive_backing.log&highlightStart=&highlightEnd=&lineNumber=1445&wrapLines=false&showLineNumbers=true&jumpToHighlight=false) at line number 1446: 
It was counting from 1001 instead of proceeding with 1447.
