### PR TITLE
Allow using asText=true to skip downloading a log as an arraybuffer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,26 @@
+language: node_js
+sudo: false
+cache:
+  directories:
+    - $HOME/.npm
+    - $HOME/.yarn-cache
+    - node_modules
+node_js:
+- '6'
+env:
+  global:
+    secure: zn10PoglN38Wf57bGMk3hsGgoVCPoPAg9dkEA6xA3YnTcsR3JQtwC2FfBPYHzcyTSewLyJre/XonekslDdlpL+vHTTC0L3JhjT0DLD9rxolcIs0t58eb+47IPC5MJ7vEldspp9a7Rg2fLVAyAna0wmpxpu3dGgYKQFpKhJwfDAfm7y009EFHc7vx7AG9wMxxT8MMpuWxx3URZCuzCAMMlIZarW/kkeJLu257cF065oHDVMFoDZh/ynJSUfvRMiwdAsCPitiwDTtL5CBJ64Sv7waibKBN7VDk1Bz5HyevtxFHUB1NDvtJX7jvS70ccV8yS89waWzi0f/f0Iw0OzK4Y2d2bgoIDRuQRlHmZgATQ55Mfzr0c/oTidQQBWqMjxU7B2+d2wawS2QfmfSvbz/TkimWXCZzvrwrT3Hbi5xxc1u1JZnKk06Rm0I8+JXjnSHDJEoEHRSfNcFewLhiX7R4lbXkhSxgxbrTIQDsEUmcG7wxsvQWyVmvR8BB7XcCLEaIUmF8mG9n867gOeD/xPvLemIZIfFXp6SXej2HYt978j0YCPnYVzReO9V6hsbVu4DdNMKd4nNrEK+fDu8u/XwNisxdgF14k9+1qF9So2PGspBZ68BnZO+G6Fbbj2ha13axE3YQOM1cu/qNbLZQzMFjspc3E9+l5WRPRmSnYabkPZw=
+before_install:
+  - npm install --global yarn --cache-min 999999999
+install:
+  - yarn
+script:
+  - yarn test
+deploy:
+  provider: script
+  skip_cleanup: true
+  script: deploy.sh
+  on:
+    repo: taskcluster/unified-logviewer
+    branch: master
+    node: '6'

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+set -o errexit -o nounset
+
+SOURCE_BRANCH="master"
+TARGET_BRANCH="gh-pages"
+BUILD_DIR="build"
+
+if [ "$TRAVIS_BRANCH" != "$SOURCE_BRANCH" ]; then
+    echo "Non-$SOURCE_BRANCH branch build; skipping deployment."
+    exit 0
+fi
+
+SHA=`git rev-parse --short HEAD`
+
+cd $BUILD_DIR
+git init
+git config user.name "Travis CI"
+git config user.email "$COMMIT_AUTHOR_EMAIL"
+
+git remote add upstream "https://$GH_TOKEN@github.com/taskcluster/unified-logviewer.git"
+git fetch upstream
+git reset upstream/$TARGET_BRANCH
+
+touch .
+
+git add -A .
+git commit -m "Rebuilding $TARGET_BRANCH from $SHA"
+git push -q upstream HEAD:$TARGET_BRANCH

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   },
   "scripts": {
     "build": "neutrino build",
-    "start": "PORT=4000 neutrino start"
+    "start": "PORT=4000 neutrino start",
+    "test": "neutrino build"
   },
   "keywords": [],
   "dependencies": {

--- a/src/LogViewer/index.js
+++ b/src/LogViewer/index.js
@@ -29,6 +29,7 @@ export default class LogViewer extends React.Component {
       showLineNumbers: qs.showLineNumbers !== 'false',
       jumpToHighlight: qs.jumpToHighlight === 'true',
       followLog: qs.followLog === 'true',
+      asText: qs.asText === 'true',
       isLoading: true,
       chunkHeights: [],
       offset: 0,
@@ -61,7 +62,8 @@ export default class LogViewer extends React.Component {
       wrapLines: nextState.wrapLines,
       showLineNumbers: nextState.showLineNumbers,
       jumpToHighlight: nextState.jumpToHighlight,
-      followLog: nextState.followLog
+      followLog: nextState.followLog,
+      asText: nextState.asText
     });
 
     if (!this.state.followLog && nextState.followLog) {
@@ -107,7 +109,7 @@ export default class LogViewer extends React.Component {
   }
 
   request() {
-    const { url } = this.state;
+    const { url, asText } = this.state;
 
     if (!url) {
       return this.setState({ error: true });
@@ -129,7 +131,7 @@ export default class LogViewer extends React.Component {
     };
 
     worker.addEventListener('message', handler);
-    worker.postMessage(JSON.stringify({ type: 'start', url }));
+    worker.postMessage(JSON.stringify({ type: 'start', url, useBuffer: !asText }));
 
     this.setState({ worker });
   }


### PR DESCRIPTION
With `asText=true`, the logviewer skips trying to download a log as an arraybuffer for 10 seconds and then failing, which is the case for live logs (streamed content). This is not on by default; rather it is up to the requestor to determine whether this should be switched on for a particular endpoint.