### PR TITLE
fix line number issue

### DIFF
--- a/src/LogViewer/chunk-worker.js
+++ b/src/LogViewer/chunk-worker.js
@@ -177,7 +177,7 @@ const update = (response) => {
     chunkHeights.push(LINE_CHUNK * MIN_LINE_HEIGHT);
     lineCounts.push(newlineCount);
 
-    nextSliceIndex = buffer[index + 1] === ENCODED_NEWLINE ?
+    nextSliceIndex = buffer[index] === ENCODED_CARRIAGERETURN && buffer[index + 1] === ENCODED_NEWLINE ?
       index + 2 :
       index + 1;
 

--- a/src/LogViewer/chunk-worker.js
+++ b/src/LogViewer/chunk-worker.js
@@ -176,7 +176,11 @@ const update = (response) => {
     chunks.push(buffer.slice(nextSliceIndex, index));
     chunkHeights.push(LINE_CHUNK * MIN_LINE_HEIGHT);
     lineCounts.push(newlineCount);
-    nextSliceIndex = index + 1;
+
+    nextSliceIndex = buffer[index + 1] === ENCODED_NEWLINE ?
+      index + 2 :
+      index + 1;
+
     newlineCount = 0;
   }
 


### PR DESCRIPTION
Problem: After each 1000 line, there is an empty line with the same line number. In other words, you will see lines 1000, 1001, 1001, 1002, ... 2000, 2001, 2001, 2002

Reason: The code increments `nextSliceIndex` by 1 after each chunk. However new lines can either be `\r\n` or `\r`. When `buffer[index] === ENCODED_CARRIAGERETURN`, the next slice needs to make sure it doesn't take the `\n` if the new line is represented as `\r\n`.