### PR TITLE
Better highlighting

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -207,7 +207,7 @@ i {
   min-height: 19px;
   display: flex;
 }
-#log p * {
+#log p > a {
   align-items: stretch;
 }
 #log p.highlight {

--- a/src/app.css
+++ b/src/app.css
@@ -205,6 +205,10 @@ i {
   padding: 0 15px 0 55px;
   margin: 0;
   min-height: 19px;
+  display: flex;
+}
+#log p * {
+  align-items: stretch;
 }
 #log p.highlight {
   background-color: #666;


### PR DESCRIPTION
This PR should fix the issue of the error highlighting looking jacked. 

Error highlighting should now look like that:
<img width="1033" alt="screen shot 2016-11-21 at 12 54 19 pm" src="https://cloud.githubusercontent.com/assets/3766511/20494167/b9b788a2-afe9-11e6-80a4-c57792e8c224.png">


