### PR TITLE
remove !important from css selector

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -215,7 +215,7 @@ i {
   color: white;
 }
 #log p:hover {
-  background-color: #444 !important;
+  background-color: #444;
 }
 #log p a {
   -webkit-user-select: none;


### PR DESCRIPTION
`!important` is not required and I can't seem to override this style from treeherder's logviewer unless i make the selector more specific which is not necessarily a good idea.