### PR TITLE
modify the current history entry instead of creating a new one

### DIFF
--- a/src/LogViewer/index.js
+++ b/src/LogViewer/index.js
@@ -75,7 +75,7 @@ export default class LogViewer extends React.Component {
       parent.postMessage(JSON.stringify(qs), '*');
     }
 
-    history.pushState(null, '', `${location.origin}${location.pathname}?${stringify(qs)}`);
+    history.replaceState(null, '', `${location.origin}${location.pathname}?${stringify(qs)}`);
   }
 
   shouldComponentUpdate(nextProps, nextState) {


### PR DESCRIPTION
Browsing through the logviewer then clicking back should take you to the previous website. 

Problem: `history.pushState` creates a new history entry