### PR TITLE
Add .line to paragraph tag

### DIFF
--- a/src/LogViewer/chunk-worker.js
+++ b/src/LogViewer/chunk-worker.js
@@ -210,8 +210,8 @@ const loadEnd = () => self.postMessage(JSON.stringify({ type: 'loadend' }));
 
 const getParagraphClass = (lineNumber, { highlightStart, highlightEnd }) => {
   return lineNumber >= highlightStart && lineNumber <= highlightEnd ?
-    ' class="highlight"' :
-    '';
+    ' class="line highlight"' :
+    ' class="line"';
 };
 
 const escape = (string) => string.replace(ESCAPE_REGEX, ESCAPE_FUNCTION);

--- a/src/app.css
+++ b/src/app.css
@@ -208,10 +208,10 @@ i {
 #log p > a {
   align-items: stretch;
 }
-#log p.highlight {
+#log .highlight {
   background-color: #666;
 }
-#log p.highlight a {
+#log .highlight a {
   color: white;
 }
 #log p:hover {


### PR DESCRIPTION
Copy-pasting from the logviewer introduces empty lines in between. This is because we are using `<p>` tags to wrap a line in the viewer. Switching `<p>` to `<div>` fixes the problem. Since the logviewer within Treeherder is styling based on tags, we will need to do this change in 3 steps in order to avoid downtime. This PR does the first step.

Steps:
1. **logviewer-pr**: Change `<p>` to `<p class="line...>`
2. **th-pr**: p=> Change Treeherder logviewer styling to use `.line` instead of `p`
3. **logviewer-pr**: Change `<p class="line...>` to `<div class="line...>`