### PR TITLE
Replace viewer to use div instead of p tag to represent a line

### DIFF
--- a/src/LogViewer/chunk-worker.js
+++ b/src/LogViewer/chunk-worker.js
@@ -208,7 +208,7 @@ const update = (response) => {
 const error = () => self.postMessage(JSON.stringify({ type: 'error' }));
 const loadEnd = () => self.postMessage(JSON.stringify({ type: 'loadend' }));
 
-const getParagraphClass = (lineNumber, { highlightStart, highlightEnd }) => {
+const wrapperClass = (lineNumber, { highlightStart, highlightEnd }) => {
   return lineNumber >= highlightStart && lineNumber <= highlightEnd ?
     ' class="line highlight"' :
     ' class="line"';
@@ -225,16 +225,16 @@ const toHtml = (index, metadata) => {
 
   const html = lines.map((parts, index) => {
     const lineNumber = start + index;
-    const pClass = getParagraphClass(lineNumber, metadata);
+    const divClass = wrapperClass(lineNumber, metadata);
 
-    return `<p${pClass}><a id="${lineNumber}">${lineNumber}</a>${parts.map((part) => {
+    return `<div${divClass}><a id="${lineNumber}">${lineNumber}</a>${parts.map((part) => {
       const className = getAnsiClasses(part);
       const html = escapeHtml`${part.text}`;
       
       return className ?
         `<span class="${className}">${html}</span>` :
         `<span>${html}</span>`;
-      }).join('')}</p>`;
+      }).join('')}</div>`;
   }).join('');
 
   self.postMessage(JSON.stringify({ type: 'decoded-index', index, html }));

--- a/src/app.css
+++ b/src/app.css
@@ -196,16 +196,16 @@ i {
 #log.wrap-lines {
   white-space: pre-wrap;
 }
-#log.show-line-numbers p a {
+#log.show-line-numbers .line a {
   display: inline-block;
 }
-#log p {
+#log .line {
   position: relative;
   display: flex;
   padding: 0 15px 0 55px;
   margin: 0;
 }
-#log p > a {
+#log .line > a {
   align-items: stretch;
 }
 #log .highlight {
@@ -214,10 +214,10 @@ i {
 #log .highlight a {
   color: white;
 }
-#log p:hover {
+#log .line:hover {
   background-color: #444;
 }
-#log p a {
+#log .line a {
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;


### PR DESCRIPTION
Copy-pasting from the logviewer introduces empty lines in between. This is because we are using `<p>` tags to wrap a line in the viewer. Switching `<p>` to `<div>` fixes the problem. Since the logviewer within Treeherder is styling based on tags, we will need to do this change in 3 steps in order to avoid downtime. This PR does the **third** step.

Steps:
1. **logviewer-pr**: Change `<p>` to `<p class="line...>`
2. **th-pr**: p=> Change Treeherder logviewer styling to use `.line` instead of `p`
3. **logviewer-pr**: Change `<p class="line...>` to `<div class="line...>`