### PR TITLE
Remove upper margin in log container (#34)

### DIFF
--- a/src/LogViewer/index.js
+++ b/src/LogViewer/index.js
@@ -278,7 +278,7 @@ export default class LogViewer extends React.Component {
   jumpToLine(lineNumber) {
     const { offset, lineHeight } = this.state;
 
-    window.scrollTo(0, (lineNumber - offset) * lineHeight + 35);
+    window.scrollTo(0, (lineNumber - offset) * lineHeight);
     this.setState({ didLineJump: true });
   }
 

--- a/src/app.css
+++ b/src/app.css
@@ -232,9 +232,6 @@ i {
 }
 
 #log-container {
-  position: relative;
-  height: calc(100% - 35px);
-  margin-top: 35px;
   padding-top: 15px;
 }
 


### PR DESCRIPTION
This removes the upper margin in the log container, to remove the unnecessary real estate consumed when viewing the topmost log lines.

Currrent:

![current](https://cloud.githubusercontent.com/assets/3660661/24580611/c2bf6c34-16d8-11e7-948c-1dea323969e7.jpg)

Proposed:

![proposed](https://cloud.githubusercontent.com/assets/3660661/24580614/d2ee2a14-16d8-11e7-85c9-0484efcd06a7.jpg)

Treeherder current:

![treeherdercurrent](https://cloud.githubusercontent.com/assets/3660661/24580646/78da31f2-16d9-11e7-92bf-2f4fb1e0e627.jpg)

Treeherder proposed:

![treeherderproposed](https://cloud.githubusercontent.com/assets/3660661/24580653/8ab3f4bc-16d9-11e7-9dae-913f6f7686bd.jpg)


Other than simulating it above in TaskCluster and Treeherder in inspector, I can't vouch for any local testing of this change due to unified-logviewer install issues in Issue https://github.com/taskcluster/unified-logviewer/issues/33
